### PR TITLE
Fix sending tracks on Sharp devices

### DIFF
--- a/src/netmd-commands.ts
+++ b/src/netmd-commands.ts
@@ -170,13 +170,19 @@ export async function download(
         // Ignore. Assume there wasn't anything to finalize
     }
 
-    await mdIface.disableNewTrackProtection(1);
+    await mdIface.acquire();
+    try {
+        await mdIface.disableNewTrackProtection(1);
+    } catch (err) {
+        // Ignore. On Sharp devices this doesn't work anyway.
+    }
 
     const session = new MDSession(mdIface, new EKBOpenSource());
     await session.init();
     const [trk, uuid, ccid] = await session.downloadTrack(track, progressCallback);
 
     await session.close();
+    await mdIface.release();
 
     return [trk, uuid, ccid];
 }

--- a/src/netmd-interface.ts
+++ b/src/netmd-interface.ts
@@ -620,6 +620,7 @@ export class NetMDInterface {
         let message = concatUint8Arrays(new Uint8Array([1, 1, 1, 1]), contentid, keyenckey);
         const encryptedarg = Crypto.DES.encrypt(Crypto.lib.WordArray.create(message), Crypto.enc.Hex.parse(hexSessionKey), {
             mode: Crypto.mode.CBC,
+            padding: Crypto.pad.NoPadding,
             iv: Crypto.enc.Hex.parse('0000000000000000'),
         });
 
@@ -635,6 +636,7 @@ export class NetMDInterface {
         }
         const authentication = Crypto.DES.encrypt(Crypto.enc.Hex.parse('0000000000000000'), Crypto.enc.Hex.parse(hexSessionKey), {
             mode: Crypto.mode.ECB,
+            padding: Crypto.pad.NoPadding,
         });
         const query = formatQuery('1800 080046 f0030103 48 ff 00 1001 %w %*', tracknum, wordArrayToByteArray(authentication.ciphertext));
         const reply = await this.sendQuery(query);


### PR DESCRIPTION
This fixes sending tracks to the Sharp IM-DR420H. I don't know whether the Sharp doesn't support disabling track protection or if something else is wrong, so I just added a try-catch block.

On two instances, `Crypto.pad.NoPadding` were added, because the Sharp requires the setup packet to contain only 32 bytes of crypto data.

Further, `acquire()` and `release()` need to be called for exclusive access during an encrypted session.