### PR TITLE
Add Sony MDS-A1

### DIFF
--- a/src/netmd.ts
+++ b/src/netmd.ts
@@ -48,6 +48,7 @@ export const DevicesIds = [
     { vendorId: 0x054c, deviceId: 0x023c, name: 'Sony DS-HMD1' },
     { vendorId: 0x054c, deviceId: 0x0286, name: 'Sony MZ-RH1' },
     { vendorId: 0x054c, deviceId: 0x011a, name: 'Sony CMT-SE7' },
+    { vendorId: 0x054c, deviceId: 0x0148, name: 'Sony MDS-A1' },
     { vendorId: 0x0b28, deviceId: 0x1004, name: 'Kenwood MDX-J9' },
     { vendorId: 0x04da, deviceId: 0x23b3, name: 'Panasonic SJ-MR250' },
     { vendorId: 0x04da, deviceId: 0x23b6, name: 'Panasonic SJ-MR270' },


### PR DESCRIPTION
Add a new device: Sony MDS-A1.

I have tested the following operations with an actual MDS-A1 without any issues:
```sh
    node dist/cli.js devices
    node dist/cli.js wipe
    node dist/cli.js ls
    node dist/cli.js set_raw_title "test-adding-device"
    node dist/cli.js upload raw-audio.raw --format sp
    node dist/cli.js rename 0 test-01
    node dist/cli.js rename 1 test-02
    node dist/cli.js move 0 1
```

I think after this PR has been merged, we can update Web Minidisc/Pro project to use this new version.

Thanks.